### PR TITLE
Add ServiceMonitor for scraping metrics using PrometheusOperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,17 +175,34 @@ following topics:
 
 ### Service configuration
 
-| Name                               | Description                                                                                 | Value          |
-| ---------------------------------- | ------------------------------------------------------------------------------------------- | -------------- |
-| `service.annotations`              | Service annotations                                                                         | `{}`           |
-| `service.clusterIP`                | Cyral Sidecar service Cluster IP                                                            | `""`           |
-| `service.externalTrafficPolicy`    | Enable client source IP preservation                                                        | `Cluster`      |
-| `service.loadBalancerClass`        | service Load Balancer class if service type is `LoadBalancer` (optional, cloud specific)    | `""`           |
-| `service.loadBalancerIP`           | LoadBalancer service IP address                                                             | `""`           |
-| `service.loadBalancerSourceRanges` | Cyral Sidecar service Load Balancer sources                                                 | `[]`           |
-| `service.nodePorts`                | Specify the nodePort(s) value(s) for the LoadBalancer and NodePort service types.           | `{}`           |
-| `service.ports`                    | Map of Cyral Sidecar service ports                                                          | `{}`           |
-| `service.sessionAffinity`          | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                        | `None`         |
-| `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                 | `{}`           |
-| `service.targetPort`               | Target port reference value for the Loadbalancer service types can be specified explicitly. | `{}`           |
-| `service.type`                     | Service type                                                                                | `LoadBalancer` |
+| Name                                       | Description                                                                                 | Value          |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------- | -------------- |
+| `service.annotations`                      | Service annotations                                                                         | `{}`           |
+| `service.clusterIP`                        | Cyral Sidecar service Cluster IP                                                            | `""`           |
+| `service.externalTrafficPolicy`            | Enable client source IP preservation                                                        | `Cluster`      |
+| `service.loadBalancerClass`                | service Load Balancer class if service type is `LoadBalancer` (optional, cloud specific)    | `""`           |
+| `service.loadBalancerIP`                   | LoadBalancer service IP address                                                             | `""`           |
+| `service.loadBalancerSourceRanges`         | Cyral Sidecar service Load Balancer sources                                                 | `[]`           |
+| `service.nodePorts`                        | Specify the nodePort(s) value(s) for the LoadBalancer and NodePort service types.           | `{}`           |
+| `service.ports`                            | Map of Cyral Sidecar service ports                                                          | `{}`           |
+| `service.sessionAffinity`                  | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                        | `None`         |
+| `service.sessionAffinityConfig`            | Additional settings for the sessionAffinity                                                 | `{}`           |
+| `service.targetPort`                       | Target port reference value for the Loadbalancer service types can be specified explicitly. | `{}`           |
+| `service.type`                             | Service type                                                                                | `LoadBalancer` |
+| `metrics.enabled`                          | Enable exposing Cyral Sidecar metrics to be gathered by Prometheus                          | `false`        |
+| `metrics.podAnnotations`                   | Annotations for enabling prometheus to access the metrics endpoint                          | `{}`           |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                | `false`        |
+| `metrics.serviceMonitor.namespace`         | Specify the namespace in which the serviceMonitor resource will be created                  | `""`           |
+| `metrics.serviceMonitor.interval`          | Specify the interval at which metrics should be scraped                                     | `30s`          |
+| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                         | `""`           |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.           | `""`           |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping.                                         | `[]`           |
+| `metrics.serviceMonitor.metricRelabelings` | MetricsRelabelConfigs to apply to samples before ingestion.                                 | `[]`           |
+| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels                    | `false`        |
+| `metrics.serviceMonitor.targetLabels`      | Used to keep given service's labels in target                                               | `{}`           |
+| `metrics.serviceMonitor.podTargetLabels`   | Used to keep given pod's labels in target                                                   | `{}`           |
+| `metrics.serviceMonitor.path`              | Define the path used by ServiceMonitor to scrap metrics                                     | `""`           |
+| `metrics.serviceMonitor.params`            | Define the HTTP URL parameters used by ServiceMonitor                                       | `{}`           |
+| `metrics.serviceMonitor.selector`          | ServiceMonitor selector labels                                                              | `{}`           |
+| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                         | `{}`           |
+| `metrics.serviceMonitor.annotations`       | Extra annotations for the ServiceMonitor                                                    | `{}`           |

--- a/README.md
+++ b/README.md
@@ -175,34 +175,39 @@ following topics:
 
 ### Service configuration
 
-| Name                                       | Description                                                                                 | Value          |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------- | -------------- |
-| `service.annotations`                      | Service annotations                                                                         | `{}`           |
-| `service.clusterIP`                        | Cyral Sidecar service Cluster IP                                                            | `""`           |
-| `service.externalTrafficPolicy`            | Enable client source IP preservation                                                        | `Cluster`      |
-| `service.loadBalancerClass`                | service Load Balancer class if service type is `LoadBalancer` (optional, cloud specific)    | `""`           |
-| `service.loadBalancerIP`                   | LoadBalancer service IP address                                                             | `""`           |
-| `service.loadBalancerSourceRanges`         | Cyral Sidecar service Load Balancer sources                                                 | `[]`           |
-| `service.nodePorts`                        | Specify the nodePort(s) value(s) for the LoadBalancer and NodePort service types.           | `{}`           |
-| `service.ports`                            | Map of Cyral Sidecar service ports                                                          | `{}`           |
-| `service.sessionAffinity`                  | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                        | `None`         |
-| `service.sessionAffinityConfig`            | Additional settings for the sessionAffinity                                                 | `{}`           |
-| `service.targetPort`                       | Target port reference value for the Loadbalancer service types can be specified explicitly. | `{}`           |
-| `service.type`                             | Service type                                                                                | `LoadBalancer` |
-| `metrics.enabled`                          | Enable exposing Cyral Sidecar metrics to be gathered by Prometheus                          | `false`        |
-| `metrics.podAnnotations`                   | Annotations for enabling prometheus to access the metrics endpoint                          | `{}`           |
-| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                | `false`        |
-| `metrics.serviceMonitor.namespace`         | Specify the namespace in which the serviceMonitor resource will be created                  | `""`           |
-| `metrics.serviceMonitor.interval`          | Specify the interval at which metrics should be scraped                                     | `30s`          |
-| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                         | `""`           |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.           | `""`           |
-| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping.                                         | `[]`           |
-| `metrics.serviceMonitor.metricRelabelings` | MetricsRelabelConfigs to apply to samples before ingestion.                                 | `[]`           |
-| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels                    | `false`        |
-| `metrics.serviceMonitor.targetLabels`      | Used to keep given service's labels in target                                               | `{}`           |
-| `metrics.serviceMonitor.podTargetLabels`   | Used to keep given pod's labels in target                                                   | `{}`           |
-| `metrics.serviceMonitor.path`              | Define the path used by ServiceMonitor to scrap metrics                                     | `""`           |
-| `metrics.serviceMonitor.params`            | Define the HTTP URL parameters used by ServiceMonitor                                       | `{}`           |
-| `metrics.serviceMonitor.selector`          | ServiceMonitor selector labels                                                              | `{}`           |
-| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                         | `{}`           |
-| `metrics.serviceMonitor.annotations`       | Extra annotations for the ServiceMonitor                                                    | `{}`           |
+| Name                               | Description                                                                                 | Value          |
+| ---------------------------------- | ------------------------------------------------------------------------------------------- | -------------- |
+| `service.annotations`              | Service annotations                                                                         | `{}`           |
+| `service.clusterIP`                | Cyral Sidecar service Cluster IP                                                            | `""`           |
+| `service.externalTrafficPolicy`    | Enable client source IP preservation                                                        | `Cluster`      |
+| `service.loadBalancerClass`        | service Load Balancer class if service type is `LoadBalancer` (optional, cloud specific)    | `""`           |
+| `service.loadBalancerIP`           | LoadBalancer service IP address                                                             | `""`           |
+| `service.loadBalancerSourceRanges` | Cyral Sidecar service Load Balancer sources                                                 | `[]`           |
+| `service.nodePorts`                | Specify the nodePort(s) value(s) for the LoadBalancer and NodePort service types.           | `{}`           |
+| `service.ports`                    | Map of Cyral Sidecar service ports                                                          | `{}`           |
+| `service.sessionAffinity`          | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                        | `None`         |
+| `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                 | `{}`           |
+| `service.targetPort`               | Target port reference value for the Loadbalancer service types can be specified explicitly. | `{}`           |
+| `service.type`                     | Service type                                                                                | `LoadBalancer` |
+
+### Prometheus metrics
+
+| Name                                       | Description                                                                      | Value   |
+| ------------------------------------------ | -------------------------------------------------------------------------------- | ------- |
+| `metrics.enabled`                          | Enable exposing Cyral Sidecar metrics to be gathered by Prometheus               | `false` |
+| `metrics.podAnnotations`                   | Annotations for enabling prometheus to access the metrics endpoint               | `{}`    |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator     | `false` |
+| `metrics.serviceMonitor.namespace`         | Specify the namespace in which the serviceMonitor resource will be created       | `""`    |
+| `metrics.serviceMonitor.interval`          | Specify the interval at which metrics should be scraped                          | `30s`   |
+| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                              | `""`    |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus | `""`    |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                               | `[]`    |
+| `metrics.serviceMonitor.metricRelabelings` | MetricsRelabelConfigs to apply to samples before ingestion                       | `[]`    |
+| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels         | `false` |
+| `metrics.serviceMonitor.targetLabels`      | Used to keep given service's labels in target                                    | `{}`    |
+| `metrics.serviceMonitor.podTargetLabels`   | Used to keep given pod's labels in target                                        | `{}`    |
+| `metrics.serviceMonitor.path`              | Define the path used by ServiceMonitor to scrap metrics                          | `""`    |
+| `metrics.serviceMonitor.params`            | Define the HTTP URL parameters used by ServiceMonitor                            | `{}`    |
+| `metrics.serviceMonitor.selector`          | ServiceMonitor selector labels                                                   | `{}`    |
+| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                              | `{}`    |
+| `metrics.serviceMonitor.annotations`       | Extra annotations for the ServiceMonitor                                         | `{}`    |

--- a/README.md
+++ b/README.md
@@ -139,6 +139,28 @@ following topics:
 | `containerPorts`      | Map of all ports inside Cyral Sidecar container                     | `{}`  |
 | `extraContainerPorts` | Array of additional container ports for the Cyral Sidecar container | `[]`  |
 
+### Prometheus metrics
+
+| Name                                       | Description                                                                      | Value   |
+| ------------------------------------------ | -------------------------------------------------------------------------------- | ------- |
+| `metrics.enabled`                          | Enable exposing Cyral Sidecar metrics to be gathered by Prometheus               | `false` |
+| `metrics.podAnnotations`                   | Annotations for enabling prometheus to access the metrics endpoint               | `{}`    |
+| `metrics.serviceMonitor.annotations`       | Extra annotations for the ServiceMonitor                                         | `{}`    |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator     | `false` |
+| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels         | `false` |
+| `metrics.serviceMonitor.interval`          | Specify the interval at which metrics should be scraped                          | `30s`   |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus | `""`    |
+| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                              | `{}`    |
+| `metrics.serviceMonitor.metricRelabelings` | MetricsRelabelConfigs to apply to samples before ingestion                       | `[]`    |
+| `metrics.serviceMonitor.namespace`         | Specify the namespace in which the serviceMonitor resource will be created       | `""`    |
+| `metrics.serviceMonitor.params`            | Define the HTTP URL parameters used by ServiceMonitor                            | `{}`    |
+| `metrics.serviceMonitor.path`              | Define the path used by ServiceMonitor to scrap metrics                          | `""`    |
+| `metrics.serviceMonitor.podTargetLabels`   | Used to keep given pod's labels in target                                        | `{}`    |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                               | `[]`    |
+| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                              | `""`    |
+| `metrics.serviceMonitor.selector`          | ServiceMonitor selector labels                                                   | `{}`    |
+| `metrics.serviceMonitor.targetLabels`      | Used to keep given service's labels in target                                    | `{}`    |
+
 ### RBAC configuration
 
 | Name          | Description                 | Value  |
@@ -189,25 +211,3 @@ following topics:
 | `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                 | `{}`           |
 | `service.targetPort`               | Target port reference value for the Loadbalancer service types can be specified explicitly. | `{}`           |
 | `service.type`                     | Service type                                                                                | `LoadBalancer` |
-
-### Prometheus metrics
-
-| Name                                       | Description                                                                      | Value   |
-| ------------------------------------------ | -------------------------------------------------------------------------------- | ------- |
-| `metrics.enabled`                          | Enable exposing Cyral Sidecar metrics to be gathered by Prometheus               | `false` |
-| `metrics.podAnnotations`                   | Annotations for enabling prometheus to access the metrics endpoint               | `{}`    |
-| `metrics.serviceMonitor.annotations`       | Extra annotations for the ServiceMonitor                                         | `{}`    |
-| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator     | `false` |
-| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels         | `false` |
-| `metrics.serviceMonitor.interval`          | Specify the interval at which metrics should be scraped                          | `30s`   |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus | `""`    |
-| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                              | `{}`    |
-| `metrics.serviceMonitor.metricRelabelings` | MetricsRelabelConfigs to apply to samples before ingestion                       | `[]`    |
-| `metrics.serviceMonitor.namespace`         | Specify the namespace in which the serviceMonitor resource will be created       | `""`    |
-| `metrics.serviceMonitor.params`            | Define the HTTP URL parameters used by ServiceMonitor                            | `{}`    |
-| `metrics.serviceMonitor.path`              | Define the path used by ServiceMonitor to scrap metrics                          | `""`    |
-| `metrics.serviceMonitor.podTargetLabels`   | Used to keep given pod's labels in target                                        | `{}`    |
-| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                               | `[]`    |
-| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                              | `""`    |
-| `metrics.serviceMonitor.selector`          | ServiceMonitor selector labels                                                   | `{}`    |
-| `metrics.serviceMonitor.targetLabels`      | Used to keep given service's labels in target                                    | `{}`    |

--- a/README.md
+++ b/README.md
@@ -196,18 +196,18 @@ following topics:
 | ------------------------------------------ | -------------------------------------------------------------------------------- | ------- |
 | `metrics.enabled`                          | Enable exposing Cyral Sidecar metrics to be gathered by Prometheus               | `false` |
 | `metrics.podAnnotations`                   | Annotations for enabling prometheus to access the metrics endpoint               | `{}`    |
-| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator     | `false` |
-| `metrics.serviceMonitor.namespace`         | Specify the namespace in which the serviceMonitor resource will be created       | `""`    |
-| `metrics.serviceMonitor.interval`          | Specify the interval at which metrics should be scraped                          | `30s`   |
-| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                              | `""`    |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus | `""`    |
-| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                               | `[]`    |
-| `metrics.serviceMonitor.metricRelabelings` | MetricsRelabelConfigs to apply to samples before ingestion                       | `[]`    |
-| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels         | `false` |
-| `metrics.serviceMonitor.targetLabels`      | Used to keep given service's labels in target                                    | `{}`    |
-| `metrics.serviceMonitor.podTargetLabels`   | Used to keep given pod's labels in target                                        | `{}`    |
-| `metrics.serviceMonitor.path`              | Define the path used by ServiceMonitor to scrap metrics                          | `""`    |
-| `metrics.serviceMonitor.params`            | Define the HTTP URL parameters used by ServiceMonitor                            | `{}`    |
-| `metrics.serviceMonitor.selector`          | ServiceMonitor selector labels                                                   | `{}`    |
-| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                              | `{}`    |
 | `metrics.serviceMonitor.annotations`       | Extra annotations for the ServiceMonitor                                         | `{}`    |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator     | `false` |
+| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels         | `false` |
+| `metrics.serviceMonitor.interval`          | Specify the interval at which metrics should be scraped                          | `30s`   |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus | `""`    |
+| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                              | `{}`    |
+| `metrics.serviceMonitor.metricRelabelings` | MetricsRelabelConfigs to apply to samples before ingestion                       | `[]`    |
+| `metrics.serviceMonitor.namespace`         | Specify the namespace in which the serviceMonitor resource will be created       | `""`    |
+| `metrics.serviceMonitor.params`            | Define the HTTP URL parameters used by ServiceMonitor                            | `{}`    |
+| `metrics.serviceMonitor.path`              | Define the path used by ServiceMonitor to scrap metrics                          | `""`    |
+| `metrics.serviceMonitor.podTargetLabels`   | Used to keep given pod's labels in target                                        | `{}`    |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                               | `[]`    |
+| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                              | `""`    |
+| `metrics.serviceMonitor.selector`          | ServiceMonitor selector labels                                                   | `{}`    |
+| `metrics.serviceMonitor.targetLabels`      | Used to keep given service's labels in target                                    | `{}`    |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
+        {{- if and .Values.metrics.enabled .Values.metrics.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "cyral.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ template "cyral.serviceAccountName" . }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,57 @@
+{{- /*
+Copyright Cyral, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.metrics.serviceMonitor.namespace | quote }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+  {{- if or .Values.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel | quote }}
+  endpoints:
+    - port: metrics
+      {{- if .Values.metrics.serviceMonitor.path }}
+      path: {{ .Values.metrics.serviceMonitor.path }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.params }}
+      params: {{ toYaml .Values.metrics.serviceMonitor.params | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.relabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "common.names.namespace" . | quote }}
+  {{- if .Values.metrics.serviceMonitor.podTargetLabels }}
+  podTargetLabels: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.podTargetLabels "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.metrics.serviceMonitor.targetLabels }}
+  targetLabels: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.targetLabels "context" $) | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
+      {{- if .Values.metrics.serviceMonitor.selector }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -102,6 +102,25 @@
 ## @param service.targetPort [object] Target port reference value for the Loadbalancer service types can be specified explicitly.
 ## @param service.type Service type
 
+## @section Prometheus metrics
+## @param metrics.enabled Enable exposing Cyral Sidecar metrics to be gathered by Prometheus
+## @param metrics.podAnnotations [object] Annotations for enabling prometheus to access the metrics endpoint
+## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
+## @param metrics.serviceMonitor.namespace Specify the namespace in which the serviceMonitor resource will be created
+## @param metrics.serviceMonitor.interval Specify the interval at which metrics should be scraped
+## @param metrics.serviceMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in Prometheus
+## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
+## @param metrics.serviceMonitor.metricRelabelings MetricsRelabelConfigs to apply to samples before ingestion
+## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
+## @param metrics.serviceMonitor.targetLabels Used to keep given service's labels in target
+## @param metrics.serviceMonitor.podTargetLabels Used to keep given pod's labels in target
+## @param metrics.serviceMonitor.path Define the path used by ServiceMonitor to scrap metrics
+## @param metrics.serviceMonitor.params Define the HTTP URL parameters used by ServiceMonitor
+## @param metrics.serviceMonitor.selector ServiceMonitor selector labels
+## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
+## @param metrics.serviceMonitor.annotations Extra annotations for the ServiceMonitor
+
 cyral:
   sidecarId: ""
   controlPlane: ""
@@ -351,11 +370,8 @@ service:
 ## Prometheus Metrics
 ##
 metrics:
-  ## @param metrics.enabled Enable exposing Cyral Sidecar metrics to be gathered by Prometheus
-  ##
   enabled: false
   ## Prometheus pod annotations
-  ## @param metrics.podAnnotations [object] Annotations for enabling prometheus to access the metrics endpoint
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations:
@@ -365,59 +381,34 @@ metrics:
   ## ref: https://github.com/coreos/prometheus-operator
   ##
   serviceMonitor:
-    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
-    ##
     enabled: false
-    ## @param metrics.serviceMonitor.namespace Specify the namespace in which the serviceMonitor resource will be created
-    ##
     namespace: ""
-    ## @param metrics.serviceMonitor.interval Specify the interval at which metrics should be scraped
-    ##
     interval: 30s
-    ## @param metrics.serviceMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
     ## e.g:
     ## scrapeTimeout: 30s
     ##
     scrapeTimeout: ""
-    ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
-    ##
     jobLabel: ""
-    ## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping.
-    ##
     relabelings: []
-    ## @param metrics.serviceMonitor.metricRelabelings MetricsRelabelConfigs to apply to samples before ingestion.
-    ##
     metricRelabelings: []
-    ## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
-    ##
     honorLabels: false
-    ## @param metrics.serviceMonitor.targetLabels Used to keep given service's labels in target
     ## e.g:
     ## - app.kubernetes.io/name
     ##
     targetLabels: {}
-    ## @param metrics.serviceMonitor.podTargetLabels Used to keep given pod's labels in target
     ## e.g:
     ## - app.kubernetes.io/name
     ##
     podTargetLabels: {}
-    ## @param metrics.serviceMonitor.path Define the path used by ServiceMonitor to scrap metrics
     ## Could be /metrics for aggregated metrics or /metrics/per-object for more details
     ##
     path: ""
-    ## @param metrics.serviceMonitor.params Define the HTTP URL parameters used by ServiceMonitor
-    ##
     params: {}
-    ## @param metrics.serviceMonitor.selector ServiceMonitor selector labels
     ## ref: https://github.com/bitnami/charts/tree/main/bitnami/prometheus-operator#prometheus-configuration
     ##
     ## selector:
     ##   prometheus: my-prometheus
     ##
     selector: {}
-    ## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
-    ##
     labels: {}
-    ## @param metrics.serviceMonitor.annotations Extra annotations for the ServiceMonitor
-    ##
     annotations: {}

--- a/values.yaml
+++ b/values.yaml
@@ -105,21 +105,21 @@
 ## @section Prometheus metrics
 ## @param metrics.enabled Enable exposing Cyral Sidecar metrics to be gathered by Prometheus
 ## @param metrics.podAnnotations [object] Annotations for enabling prometheus to access the metrics endpoint
-## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
-## @param metrics.serviceMonitor.namespace Specify the namespace in which the serviceMonitor resource will be created
-## @param metrics.serviceMonitor.interval Specify the interval at which metrics should be scraped
-## @param metrics.serviceMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
-## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in Prometheus
-## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
-## @param metrics.serviceMonitor.metricRelabelings MetricsRelabelConfigs to apply to samples before ingestion
-## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
-## @param metrics.serviceMonitor.targetLabels Used to keep given service's labels in target
-## @param metrics.serviceMonitor.podTargetLabels Used to keep given pod's labels in target
-## @param metrics.serviceMonitor.path Define the path used by ServiceMonitor to scrap metrics
-## @param metrics.serviceMonitor.params Define the HTTP URL parameters used by ServiceMonitor
-## @param metrics.serviceMonitor.selector ServiceMonitor selector labels
-## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
 ## @param metrics.serviceMonitor.annotations Extra annotations for the ServiceMonitor
+## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
+## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
+## @param metrics.serviceMonitor.interval Specify the interval at which metrics should be scraped
+## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in Prometheus
+## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
+## @param metrics.serviceMonitor.metricRelabelings MetricsRelabelConfigs to apply to samples before ingestion
+## @param metrics.serviceMonitor.namespace Specify the namespace in which the serviceMonitor resource will be created
+## @param metrics.serviceMonitor.params Define the HTTP URL parameters used by ServiceMonitor
+## @param metrics.serviceMonitor.path Define the path used by ServiceMonitor to scrap metrics
+## @param metrics.serviceMonitor.podTargetLabels Used to keep given pod's labels in target
+## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
+## @param metrics.serviceMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+## @param metrics.serviceMonitor.selector ServiceMonitor selector labels
+## @param metrics.serviceMonitor.targetLabels Used to keep given service's labels in target
 
 cyral:
   sidecarId: ""

--- a/values.yaml
+++ b/values.yaml
@@ -63,6 +63,25 @@
 ## @param containerPorts [object] Map of all ports inside Cyral Sidecar container
 ## @param extraContainerPorts Array of additional container ports for the Cyral Sidecar container
 
+## @section Prometheus metrics
+## @param metrics.enabled Enable exposing Cyral Sidecar metrics to be gathered by Prometheus
+## @param metrics.podAnnotations [object] Annotations for enabling prometheus to access the metrics endpoint
+## @param metrics.serviceMonitor.annotations Extra annotations for the ServiceMonitor
+## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
+## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
+## @param metrics.serviceMonitor.interval Specify the interval at which metrics should be scraped
+## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in Prometheus
+## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
+## @param metrics.serviceMonitor.metricRelabelings MetricsRelabelConfigs to apply to samples before ingestion
+## @param metrics.serviceMonitor.namespace Specify the namespace in which the serviceMonitor resource will be created
+## @param metrics.serviceMonitor.params Define the HTTP URL parameters used by ServiceMonitor
+## @param metrics.serviceMonitor.path Define the path used by ServiceMonitor to scrap metrics
+## @param metrics.serviceMonitor.podTargetLabels Used to keep given pod's labels in target
+## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
+## @param metrics.serviceMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+## @param metrics.serviceMonitor.selector ServiceMonitor selector labels
+## @param metrics.serviceMonitor.targetLabels Used to keep given service's labels in target
+
 ## @section RBAC configuration
 ## @param rbac.create Create Role and RoleBinding
 ## @param rbac.rules Custom RBAC rules to set
@@ -101,25 +120,6 @@
 ## @param service.sessionAffinityConfig Additional settings for the sessionAffinity
 ## @param service.targetPort [object] Target port reference value for the Loadbalancer service types can be specified explicitly.
 ## @param service.type Service type
-
-## @section Prometheus metrics
-## @param metrics.enabled Enable exposing Cyral Sidecar metrics to be gathered by Prometheus
-## @param metrics.podAnnotations [object] Annotations for enabling prometheus to access the metrics endpoint
-## @param metrics.serviceMonitor.annotations Extra annotations for the ServiceMonitor
-## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
-## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
-## @param metrics.serviceMonitor.interval Specify the interval at which metrics should be scraped
-## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in Prometheus
-## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
-## @param metrics.serviceMonitor.metricRelabelings MetricsRelabelConfigs to apply to samples before ingestion
-## @param metrics.serviceMonitor.namespace Specify the namespace in which the serviceMonitor resource will be created
-## @param metrics.serviceMonitor.params Define the HTTP URL parameters used by ServiceMonitor
-## @param metrics.serviceMonitor.path Define the path used by ServiceMonitor to scrap metrics
-## @param metrics.serviceMonitor.podTargetLabels Used to keep given pod's labels in target
-## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
-## @param metrics.serviceMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
-## @param metrics.serviceMonitor.selector ServiceMonitor selector labels
-## @param metrics.serviceMonitor.targetLabels Used to keep given service's labels in target
 
 cyral:
   sidecarId: ""

--- a/values.yaml
+++ b/values.yaml
@@ -347,3 +347,77 @@ service:
   annotations: {}
   ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   externalTrafficPolicy: Cluster
+
+## Prometheus Metrics
+##
+metrics:
+  ## @param metrics.enabled Enable exposing Cyral Sidecar metrics to be gathered by Prometheus
+  ##
+  enabled: false
+  ## Prometheus pod annotations
+  ## @param metrics.podAnnotations [object] Annotations for enabling prometheus to access the metrics endpoint
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.service.ports.metrics }}"
+  ## Prometheus Service Monitor
+  ## ref: https://github.com/coreos/prometheus-operator
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
+    ##
+    enabled: false
+    ## @param metrics.serviceMonitor.namespace Specify the namespace in which the serviceMonitor resource will be created
+    ##
+    namespace: ""
+    ## @param metrics.serviceMonitor.interval Specify the interval at which metrics should be scraped
+    ##
+    interval: 30s
+    ## @param metrics.serviceMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+    ## e.g:
+    ## scrapeTimeout: 30s
+    ##
+    scrapeTimeout: ""
+    ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+    ##
+    jobLabel: ""
+    ## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping.
+    ##
+    relabelings: []
+    ## @param metrics.serviceMonitor.metricRelabelings MetricsRelabelConfigs to apply to samples before ingestion.
+    ##
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
+    ##
+    honorLabels: false
+    ## @param metrics.serviceMonitor.targetLabels Used to keep given service's labels in target
+    ## e.g:
+    ## - app.kubernetes.io/name
+    ##
+    targetLabels: {}
+    ## @param metrics.serviceMonitor.podTargetLabels Used to keep given pod's labels in target
+    ## e.g:
+    ## - app.kubernetes.io/name
+    ##
+    podTargetLabels: {}
+    ## @param metrics.serviceMonitor.path Define the path used by ServiceMonitor to scrap metrics
+    ## Could be /metrics for aggregated metrics or /metrics/per-object for more details
+    ##
+    path: ""
+    ## @param metrics.serviceMonitor.params Define the HTTP URL parameters used by ServiceMonitor
+    ##
+    params: {}
+    ## @param metrics.serviceMonitor.selector ServiceMonitor selector labels
+    ## ref: https://github.com/bitnami/charts/tree/main/bitnami/prometheus-operator#prometheus-configuration
+    ##
+    ## selector:
+    ##   prometheus: my-prometheus
+    ##
+    selector: {}
+    ## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
+    ##
+    labels: {}
+    ## @param metrics.serviceMonitor.annotations Extra annotations for the ServiceMonitor
+    ##
+    annotations: {}


### PR DESCRIPTION
## Description of the change

Adding `ServiceMonitor` resource to make it easy to scrape metrics using Prometheus operator.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

* Installed [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) and deployed a new sidecar with `metrics.enabled=true` and `metrics.serviceMonitor.enabled=true`
* Verified that Prometheus was pulling metrics from the sidecar:
![image](https://github.com/user-attachments/assets/4b5b2ef1-ee10-4cce-beaa-286b46402b59)

