### PR TITLE
Add missing docs and fix broken links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,6 +237,7 @@ modules.xml
 !.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
+.DS_Store
 
 # Local History for Visual Studio Code
 .history/

--- a/docs/database-accounts/aws-secrets-manager.md
+++ b/docs/database-accounts/aws-secrets-manager.md
@@ -1,0 +1,55 @@
+# Setting up database accounts to a Helm sidecar through AWS Secrets Manager
+
+Cyral recommends setting up database accounts to a Helm sidecar
+using [environment variable](./environment-variables.md) referencing Kubernetes secrets.
+
+If you prefer to use AWS Secrets Manager instead, you are required to provide the AWS 
+credentials that the sidecar will use to access the AWS secret containing the database 
+account. The Helm sidecar allows for one of the two following options to provide 
+these credentials: 
+
+* Add AWS credentials directly to the values file, which will then
+create a Kubernetes secret automatically to store them.
+* Add AWS credentials to a Kubernetes secret with the credentials and then 
+provide this secret name to the sidecar.
+
+Read more information about [database accounts](https://cyral.com/docs/data-repos/access-rules/database-accounts/)
+in our public docs.
+
+
+## Add AWS credentials directly to the values file
+
+To provide the AWS credentials directly to the values file, you need to add
+the section `aws` to your `values.yaml` as follows:
+
+```yaml
+aws:
+  enabled: true
+  secretKey: <your secret key>
+  accesskeyId: <your access key id>
+```
+
+The credentials provided to `secretKey` and `accesskeyId` will be  stored in a 
+Kubernetes secret and accessed by the sidecar through environment variables.
+
+## Add AWS credentials through a Kubernetes secret
+
+If you prefer to manually create a Kubernetes secret with the AWS credentials,
+follow the format below:
+
+```yaml
+apiVersion: v1
+kind: Secret
+stringData:
+  AWS_SECRET_KEY: <your secret key>
+  AWS_ACCESS_KEY_ID: <your access key id>
+```
+
+Once the secret is created, add the `aws` section to your `values.yaml`
+informing the secret name as follows:
+
+```yaml
+aws:
+  enabled: true
+  existingSecret: <SECRET_NAME>
+```

--- a/docs/database-accounts/environment-variables.md
+++ b/docs/database-accounts/environment-variables.md
@@ -1,0 +1,148 @@
+# Setting up database accounts to a Helm sidecar through environment variables
+
+Cyral recommends setting up database accounts to a Helm sidecar
+using environment variables referencing Kubernetes secrets.
+
+Read more information about [database accounts](https://cyral.com/docs/data-repos/access-rules/database-accounts/)
+in our public docs.
+
+## Add the credentials to your cluster
+
+To add credentials for a repository using kubernetes secrets and environment
+variables, you need to create a secret containing those credentials in the
+same namespace as the sidecar you are deploying.
+
+Use one of the next 3 options in the sections below to create a secret: 
+- from a file containing the credentials
+- from a literal in the command line
+- from a secret yaml file
+
+For the selected option, define the following variables:
+- `SIDECAR_NAMESPACE`: namespace that the sidecar will be deployed to.
+- `SECRET_NAME`: name of the secret that will contain the credentials.
+- `CREDENTIALS_FILE`: name of the file containing the credentials.
+- `CREDENTIALS_CONTENT`: credentials content.
+
+### Create a secret from a file containing the credentials
+
+```bash
+kubectl create secret generic \
+  --from-file credentials=$CREDENTIALS_FILE \
+  -n $SIDECAR_NAMESPACE $SECRET_NAME
+```
+
+### Create a secret from a literal in the command line
+
+```bash
+kubectl create secret generic \
+  --from-literal credentials=$CREDENTIALS_CONTENT \
+  -n $SIDECAR_NAMESPACE $SECRET_NAME
+```
+
+### Create a secret from a secret yaml file
+
+Create a file named `secret.yaml` with the following contents:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $SECRET_NAME
+  namespace: $SIDECAR_NAMESPACE
+stringData:
+  credentials: |
+    $CREDENTIALS_CONTENT
+```
+
+Apply the file on your cluster with `kubectl`:
+
+```bash
+kubectl apply -f secret.yaml
+```
+
+## Configure the sidecar to fetch the environment variables from the credentials
+
+With the secret created, you need to add an environment variable to the `authenticator`
+field of the `values.yaml` file used to create the sidecar.
+
+```yaml
+authenticator:
+  extraEnvs:
+  - name: CYRAL_DBSECRETS_<env-var-configured-in-the-control-plane>
+    valueFrom:
+      secretKeyRef:
+        name: $SECRET_NAME
+        key: credentials
+```
+
+## Multiple credentials in a single secret
+
+You can add multiple values on each of the secret creation methods, so that
+you don't need to update the `values.yaml` file on each new repository.
+
+Use one of the next 3 options in the sections below to create a secret: 
+- from a file containing the credentials
+- from a literal in the command line
+- from a secret yaml file
+
+### Create a secret from a file containing the credentials
+
+```bash
+kubectl create secret generic \
+  -n $SIDECAR_NAMESPACE $SECRET_NAME \
+  --from-file repo1=repo1_credentials.json \
+  --from-file repo2=repo2_credentials.json
+  # ...
+```
+
+### Create a secret from a literal in the command line
+
+```bash
+kubectl create secret generic \
+  -n $SIDECAR_NAMESPACE $SECRET_NAME \
+  --from-literal repo1=<repo1 credentials> \
+  --from-literal repo2=<repo2 credentials>
+  # ...
+```
+
+### Create a secret from a secret yaml file
+
+Create a file named `secret.yaml` with the following contents:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $SECRET_NAME
+  namespace: $SIDECAR_NAMESPACE
+stringData:
+  repo1: |
+    <repo1 credentials>
+  repo2: |
+    <repo2 credentials>
+    ...
+```
+
+Apply the file to your cluster with `kubectl`:
+
+```bash
+kubectl apply -f secret.yaml
+```
+
+To add them all, just add multiple environment variables in the `values.yaml` file.
+
+```yaml
+authenticator:
+  extraEnvs:
+  - name: CYRAL_DBSECRETS_<repo1 env var>
+    valueFrom:
+      secretKeyRef:
+        name: $SECRET_NAME
+        key: repo1
+  - name: CYRAL_DBSECRETS_<repo2 env var>
+    valueFrom:
+      secretKeyRef:
+        name: $SECRET_NAME
+        key: repo2
+  ...
+```


### PR DESCRIPTION
Two links were broken in the main `README` page due to a miss in a previous PR when we moved the docs from the quickstart to this repository. This PR fixes the issue.